### PR TITLE
Add vmagent and remove alloy

### DIFF
--- a/charts/oodle-k8s-observability/Chart.lock
+++ b/charts/oodle-k8s-observability/Chart.lock
@@ -1,7 +1,4 @@
 dependencies:
-- name: k8s-monitoring
-  repository: https://oodle-ai.github.io/helm-charts
-  version: 1.2.1
 - name: oodle-k8s-auto-instrumentation
   repository: https://oodle-ai.github.io/helm-charts
   version: 1.2.9
@@ -13,6 +10,15 @@ dependencies:
   version: 0.43.0
 - name: kubernetes-event-exporter
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.5.5
-digest: sha256:a071e2e58a854790bd48b941ded25c75d4b0d6eaea2e6abf7c9fed714039fe98
-generated: "2025-06-12T12:38:44.583836+05:30"
+  version: 3.5.6
+- name: victoria-metrics-agent
+  repository: https://victoriametrics.github.io/helm-charts/
+  version: 0.23.0
+- name: kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 5.37.0
+- name: prometheus-node-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.47.0
+digest: sha256:eace49d75e08d9cbf13c952dca3feee64f1700a609e0a0dac7a987d852941fb2
+generated: "2025-06-25T15:12:35.906642+05:30"

--- a/charts/oodle-k8s-observability/Chart.yaml
+++ b/charts/oodle-k8s-observability/Chart.yaml
@@ -22,11 +22,6 @@ keywords:
   - instrumentation
 
 dependencies:
-  - name: k8s-monitoring
-    version: "^1.0.0"
-    repository: "https://oodle-ai.github.io/helm-charts"
-    alias: monitoring
-    condition: monitoring.enabled
   - name: oodle-k8s-auto-instrumentation
     version: "^1.0.0"
     repository: "https://oodle-ai.github.io/helm-charts"
@@ -46,4 +41,19 @@ dependencies:
     version: "^3.0.0"
     repository: "oci://registry-1.docker.io/bitnamicharts"
     alias: event-exporter
-    condition: event-exporter.enabled 
+    condition: event-exporter.enabled
+  - name: victoria-metrics-agent
+    version: "^0.23.0"
+    repository: "https://victoriametrics.github.io/helm-charts/"
+    alias: vmagent
+    condition: vmagent.enabled
+  - name: kube-state-metrics
+    version: "^5.0.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    alias: kube-state-metrics
+    condition: kube-state-metrics.enabled
+  - name: prometheus-node-exporter
+    version: "^4.0.0"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    alias: prometheus-node-exporter
+    condition: prometheus-node-exporter.enabled 

--- a/charts/oodle-k8s-observability/Chart.yaml
+++ b/charts/oodle-k8s-observability/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oodle-k8s-observability
 description: A Helm chart for Oodle Kubernetes observability stack
 type: application
-version: 1.0.2
-appVersion: "1.0.2"
+version: 1.0.3
+appVersion: "1.0.3"
 home: https://github.com/oodle-ai/oodle-k8s-observability-helm
 sources:
   - https://github.com/oodle-ai/oodle-k8s-observability-helm

--- a/charts/oodle-k8s-observability/templates/NOTES.txt
+++ b/charts/oodle-k8s-observability/templates/NOTES.txt
@@ -1,7 +1,7 @@
 🎉 Oodle Kubernetes Observability has been installed successfully!
 
 Components installed:
-{{- if .Values.monitoring.enabled }}
+{{- if .Values.vmagent.enabled }}
 ✅ Metrics
 {{- else }}
 ❌ Metrics - Disabled

--- a/charts/oodle-k8s-observability/values.yaml
+++ b/charts/oodle-k8s-observability/values.yaml
@@ -116,6 +116,9 @@ vmagent:
           - source_labels: [__meta_kubernetes_node_name]
             target_label: instance
             replacement: $1
+          - source_labels: [ __meta_kubernetes_node_name ]
+            target_label: node
+            replacement: $1
         honor_timestamps: false
 
       # Scrape cAdvisor metrics (container metrics) using direct mode
@@ -208,6 +211,9 @@ vmagent:
           - source_labels: [__meta_kubernetes_pod_node_name]
             action: replace
             target_label: node
+          - source_labels: [ __meta_kubernetes_pod_node_name ]
+            target_label: instance
+            replacement: $1
           # Set cardinality limit for auto-instrumentation targets
           - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
             regex: ".*beyla.*"

--- a/charts/oodle-k8s-observability/values.yaml
+++ b/charts/oodle-k8s-observability/values.yaml
@@ -1,76 +1,220 @@
-# Configuration for k8s-monitoring chart (using alias: monitoring)
-monitoring:
+# Configuration for kube-state-metrics chart
+kube-state-metrics:
   enabled: true
-  cluster:
-    name: "" # Kubernetes Cluster Name
+
+# Configuration for prometheus-node-exporter chart  
+prometheus-node-exporter:
+  enabled: true
   
-  externalServices:
-    prometheus:
-      host: ""  # Oodle Metrics Host
-      apiKey: "" # Oodle API Key
-      writeEndpoint: "" # Oodle Prometheus Metrics Write Endpoint
+  # Use custom port to avoid conflicts with other node exporters
+  service:
+    port: 9301
+    targetPort: 9301
 
-  metrics:
-    alloy:
-      metricsTuning:
-        useIntegrationAllowList: true
-    kube-state-metrics:
-      metricsTuning:
-        useDefaultAllowList: false
-    node-exporter:
-      metricsTuning:
-        useDefaultAllowList: false
-    cadvisor:
-      metricsTuning:
-        useDefaultAllowList: false
+# Configuration for Metrics
+vmagent:
+  enabled: true
 
-  kube-state-metrics:
+  mode: statefulSet
+
+  # Number of vmagent replicas for sharding
+  replicaCount: 2
+
+  # Enable sharding across replicas
+  extraArgs:
+    promscrape.cluster.membersCount: "2"
+    promscrape.cluster.replicationFactor: "1"
+    # Each replica will get its memberNum from environment variable
+    promscrape.cluster.memberNum: "$(MEMBER_NUM)"
+
+  # Environment variables for sharding - pod ordinal will be set automatically
+  env:
+    - name: MEMBER_NUM
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+
+  # StatefulSet configuration for parallel deployment
+  statefulSet:
+    spec:
+      podManagementPolicy: "Parallel"
+
+  # Persistent volume for each replica to store scrape queue
+  persistentVolume:
     enabled: true
+    size: 20Gi
+    storageClass: ""
 
-  prometheus-node-exporter:
+  # Resource limits for each replica
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+  # Pod disruption budget to ensure availability during updates
+  podDisruptionBudget:
     enabled: true
-    
-  prometheus-operator-crds:
-    enabled: false
+    minAvailable: 1
 
-  logs:
-    enabled: false
-    pod_logs:
-      enabled: false
-    cluster_events:
-      enabled: false
+  # Add prometheus annotations for self-discovery
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8429"
+    prometheus.io/path: "/metrics"
 
-  events:
-    enabled: false
-  traces:
-    enabled: false
-  profiles:
-    enabled: false
-  cluster_events:
-    enabled: false
-  receivers:
-    grpc:
-      enabled: false
-    http:
-      enabled: false
-    grafanaCloudMetrics:
-      enabled: false
-    deployGrafanaAgentService: false
+  # Remote write configuration for sending metrics to Oodle
+  remoteWrite:
+    - url: "" # Oodle Prometheus Metrics Write Endpoint
+      headers: "X-API-KEY: <>" # Oodle API Key
 
-  test:
-    enabled: false
-  configAnalysis:
-    enabled: false
-  opencost:
-    enabled: false
+  # -- Extra scrape configs that will be appended to `config`
+  extraScrapeConfigs: [ ]
+
+  # Scrape configuration for collecting metrics
+  config:
+    global:
+      scrape_interval: 60s
+      scrape_timeout: 1m
+      external_labels:
+        cluster: "" # Kubernetes Cluster Name
+
+    scrape_configs:
+      # Note: vmagent scrapes itself via prometheus.io/scrape annotation
+      # discovered by kubernetes-pods job below
+
+      # Scrape Kubernetes API servers
+      - job_name: kubernetes-apiservers
+        kubernetes_sd_configs:
+          - role: endpoints
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: default;kubernetes;https
+
+      # Scrape Kubelet metrics from each node using direct mode
+      - job_name: kubernetes-nodes
+        kubernetes_sd_configs:
+          - role: node
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        metrics_path: /metrics
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - source_labels: [__address__]
+            regex: ([^:]+):(.*)
+            target_label: __address__
+            replacement: $1:10250
+          # Set instance to node name (hostname) instead of IP
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: instance
+            replacement: $1
+        honor_timestamps: false
+
+      # Scrape cAdvisor metrics (container metrics) using direct mode
+      - job_name: kubernetes-nodes-cadvisor
+        kubernetes_sd_configs:
+          - role: node
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        metrics_path: /metrics/cadvisor
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - source_labels: [__address__]
+            regex: ([^:]+):(.*)
+            target_label: __address__
+            replacement: $1:10250
+          # Set instance to node name (hostname) instead of IP
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: instance
+            replacement: $1
+        honor_timestamps: false
+
+      # Scrape kube-state-metrics
+      - job_name: kube-state-metrics
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            action: keep
+            regex: ".*-kube-state-metrics"
+          - source_labels: [__meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: http
+
+      # Scrape node-exporter
+      - job_name: node-exporter
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            action: keep
+            regex: ".*node-exporter.*"
+          - source_labels: [__meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: metrics
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: instance
+            replacement: $1
+
+      # Scrape pods with prometheus.io/scrape: true annotation
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - action: drop
+            source_labels: [__meta_kubernetes_pod_container_init]
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels:
+              [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            target_label: container
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            action: replace
+            target_label: node
+          # Set cardinality limit for auto-instrumentation targets
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+            regex: ".*beyla.*"
+            target_label: __series_limit__
+            replacement: "1000000"
 
 # Configuration for oodle-k8s-auto-instrumentation chart (using alias: auto-instrumentation)
 auto-instrumentation:
   enabled: true
   beyla:
     env:
-      OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "" # Oodle Metrics Endpoint
-      OTEL_EXPORTER_OTLP_HEADERS: "" # Oodle API Key
       BEYLA_KUBE_CLUSTER_NAME: "" # Kubernetes Cluster Name
 
 # Configuration for Vector Agent
@@ -188,4 +332,3 @@ event-exporter:
             X-OODLE-INSTANCE: "${OODLE_INSTANCE}"
             X-API-KEY: "${OODLE_API_KEY}"
             X-OODLE-LOG-SOURCE: "event-exporter"
-

--- a/charts/oodle-k8s-observability/values.yaml
+++ b/charts/oodle-k8s-observability/values.yaml
@@ -1,6 +1,10 @@
 # Configuration for kube-state-metrics chart
 kube-state-metrics:
   enabled: true
+  
+  # Override labels to make this instance uniquely identifiable
+  customLabels:
+    app: oodle-kube-state-metrics
 
 # Configuration for prometheus-node-exporter chart  
 prometheus-node-exporter:
@@ -10,6 +14,10 @@ prometheus-node-exporter:
   service:
     port: 9301
     targetPort: 9301
+    
+  # Override labels to make this instance uniquely identifiable
+  commonLabels:
+    app: oodle-node-exporter
 
 # Configuration for Metrics
 vmagent:
@@ -20,22 +28,10 @@ vmagent:
   # Number of vmagent replicas for sharding
   replicaCount: 2
 
-  # Enable sharding across replicas
-  extraArgs:
-    promscrape.cluster.membersCount: "2"
-    promscrape.cluster.replicationFactor: "1"
-    # Each replica will get its memberNum from environment variable
-    promscrape.cluster.memberNum: "$(MEMBER_NUM)"
-
-  # Environment variables for sharding - pod ordinal will be set automatically
-  env:
-    - name: MEMBER_NUM
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
-
-  # StatefulSet configuration for parallel deployment
+  # StatefulSet configuration for sharding
   statefulSet:
+    clusterMode: true
+    replicationFactor: 1
     spec:
       podManagementPolicy: "Parallel"
 
@@ -145,23 +141,31 @@ vmagent:
             replacement: $1
         honor_timestamps: false
 
-      # Scrape kube-state-metrics
+      # Scrape kube-state-metrics (only the one deployed by this chart)
       - job_name: kube-state-metrics
         kubernetes_sd_configs:
           - role: endpoints
         relabel_configs:
+          # Filter by custom label to ensure we only scrape our deployed instance
+          - source_labels: [__meta_kubernetes_service_label_app]
+            action: keep
+            regex: "oodle-kube-state-metrics"
           - source_labels: [__meta_kubernetes_service_name]
             action: keep
-            regex: ".*-kube-state-metrics"
+            regex: ".*kube-state-metrics.*"
           - source_labels: [__meta_kubernetes_endpoint_port_name]
             action: keep
             regex: http
 
-      # Scrape node-exporter
+      # Scrape node-exporter (only the one deployed by this chart)
       - job_name: node-exporter
         kubernetes_sd_configs:
           - role: endpoints
         relabel_configs:
+          # Filter by custom label to ensure we only scrape our deployed instance
+          - source_labels: [__meta_kubernetes_service_label_app]
+            action: keep
+            regex: "oodle-node-exporter"
           - source_labels: [__meta_kubernetes_service_name]
             action: keep
             regex: ".*node-exporter.*"


### PR DESCRIPTION
Deploy `kube-state-metrics` and `prometheus-node-exporter` from their own helm charts rather than through alloy.

Setup vmagent to scrape required metrics from kubelet/cadvisor/ksm/node-exporter/api-server and also scrape app metrics based on `prometheus.io/scrape` annotation based discovery.

Change default port of `node-exporter` to avoid conflict so that we can always deploy it.