### PR TITLE
Add toleration for NoSchedule

### DIFF
--- a/charts/oodle-k8s-observability/Chart.lock
+++ b/charts/oodle-k8s-observability/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: oodle-k8s-auto-instrumentation
   repository: https://oodle-ai.github.io/helm-charts
-  version: 1.2.12
+  version: 1.2.13
 - name: vector
   repository: https://helm.vector.dev
   version: 0.43.0
@@ -19,6 +19,6 @@ dependencies:
   version: 5.37.0
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 4.47.0
-digest: sha256:08f5d5fc4eaee25bcc173460134e8bf569c165a06510232328329e9017d32b6b
-generated: "2025-06-28T22:36:41.73926+05:30"
+  version: 4.47.1
+digest: sha256:0788956d8e658eca44d060abb69938d8929907ec9e6d809c0bca21a2d10281b1
+generated: "2025-07-01T10:06:51.964651+05:30"

--- a/charts/oodle-k8s-observability/Chart.yaml
+++ b/charts/oodle-k8s-observability/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oodle-k8s-observability
 description: A Helm chart for Oodle Kubernetes observability stack
 type: application
-version: 1.0.6
-appVersion: "1.0.6"
+version: 1.0.7
+appVersion: "1.0.7"
 home: https://github.com/oodle-ai/oodle-k8s-observability-helm
 sources:
   - https://github.com/oodle-ai/oodle-k8s-observability-helm

--- a/charts/oodle-k8s-observability/values.yaml
+++ b/charts/oodle-k8s-observability/values.yaml
@@ -65,10 +65,10 @@ vmagent:
   remoteWrite:
     - url: "" # Oodle Prometheus Metrics Write Endpoint
       headers: "X-API-KEY: <>" # Oodle API Key
-      forcePromProto: true
 
   extraArgs:
     promscrape.suppressDuplicateScrapeTargetErrors: "true"
+    remoteWrite.forcePromProto: "true"
 
   # -- Extra scrape configs that will be appended to `config`
   extraScrapeConfigs: [ ]
@@ -272,6 +272,10 @@ vector-agent:
   env:
     - name: CLUSTER_NAME
       value: "" # Kubernetes Cluster Name
+
+  tolerations:
+    - effect: NoSchedule
+      operator: Exists
 
   customConfig:
     data_dir: /vector-data-dir


### PR DESCRIPTION
To be able to schedule vector-agent on nodes which have `NoSchedule` taint. Also, move vmagent's forcePromProto flag in extraArgs so that it need not be included in the client-side configuration