### PR TITLE
Support larger log lines

### DIFF
--- a/charts/oodle-k8s-observability/Chart.yaml
+++ b/charts/oodle-k8s-observability/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oodle-k8s-observability
 description: A Helm chart for Oodle Kubernetes observability stack
 type: application
-version: 1.0.9
-appVersion: "1.0.9"
+version: 1.0.10
+appVersion: "1.0.10"
 home: https://github.com/oodle-ai/oodle-k8s-observability-helm
 sources:
   - https://github.com/oodle-ai/oodle-k8s-observability-helm

--- a/charts/oodle-k8s-observability/values.yaml
+++ b/charts/oodle-k8s-observability/values.yaml
@@ -277,6 +277,7 @@ vector-agent:
     - effect: NoSchedule
       operator: Exists
 
+  max_line_bytes: 1048576 # 1 MiB
   # Additional filters applied to select which pods to scrape
   # Example: "app.kubernetes.io/name!=kube-state-metrics,app.kubernetes.io/name!=node-exporter"
   label_selectors: ""
@@ -294,6 +295,7 @@ vector-agent:
     sources:
       kubernetes_logs:
         type: kubernetes_logs
+        max_line_bytes: {{ .Values.max_line_bytes }}
         extra_label_selector: "{{ .Values.label_selectors }}"
         extra_namespace_label_selector: "{{ .Values.namespace_label_selectors }}"
 


### PR DESCRIPTION
Default in vector is 32KiB, support 1MiB limit and make it easily configurable via helm chart values