### PR TITLE
Add oodle-k8s-observability-fargate Helm chart

### DIFF
--- a/charts/oodle-k8s-observability-fargate/Chart.lock
+++ b/charts/oodle-k8s-observability-fargate/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kubernetes-event-exporter
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 3.6.3
+digest: sha256:a2617278738f246b6d7f7b58782ae9679d16bd1da42d2f0893c95c9140880b72
+generated: "2026-05-10T20:15:09.027633-07:00"

--- a/charts/oodle-k8s-observability-fargate/Chart.yaml
+++ b/charts/oodle-k8s-observability-fargate/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: oodle-k8s-observability-fargate
+description: A Helm chart for Oodle Kubernetes observability on EKS Fargate
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/oodle-ai/oodle-k8s-observability-helm
+sources:
+  - https://github.com/oodle-ai/oodle-k8s-observability-helm
+  - https://github.com/oodle-ai/helm-charts
+maintainers:
+  - name: Oodle AI
+    url: https://oodle.ai
+keywords:
+  - monitoring
+  - observability
+  - metrics
+  - traces
+  - logs
+  - kubernetes
+  - fargate
+  - eks
+  - opentelemetry
+
+dependencies:
+  - name: kubernetes-event-exporter
+    version: "^3.0.0"
+    repository: "oci://registry-1.docker.io/bitnamicharts"
+    alias: event-exporter
+    condition: event-exporter.enabled

--- a/charts/oodle-k8s-observability-fargate/templates/NOTES.txt
+++ b/charts/oodle-k8s-observability-fargate/templates/NOTES.txt
@@ -1,0 +1,103 @@
+🎉 Oodle Kubernetes Observability (Fargate) has been installed successfully!
+
+Components installed:
+{{- if .Values.otelGateway.enabled }}
+✅ OTel Collector Gateway (metrics{{ if .Values.traces.enabled }} + traces{{ end }})
+{{- else }}
+❌ OTel Collector Gateway - Disabled
+{{- end }}
+{{- if .Values.otelGateway.k8sCluster.enabled }}
+✅ k8s_cluster receiver (cluster object metrics via API server)
+{{- else }}
+❌ k8s_cluster receiver - Disabled
+{{- end }}
+{{- if index .Values "event-exporter" "enabled" }}
+✅ Kubernetes Events
+{{- else }}
+❌ Kubernetes Events - Disabled
+{{- end }}
+{{- if .Values.fargateLogging.enabled }}
+✅ Fargate Logging (Fluent Bit -> Oodle)
+{{- else }}
+❌ Fargate Logging - Disabled
+{{- end }}
+
+
+📦 NEXT STEP: Add the OTel sidecar to your Fargate Deployments
+
+Add the following to each Fargate Deployment you want to observe.
+All values below are pre-filled from your Helm release.
+
+1. Set the serviceAccountName and add the config volume:
+
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ include "oodle-fargate.sidecarServiceAccountName" . }}
+          volumes:
+            - name: otel-sidecar-config
+              configMap:
+                name: {{ include "oodle-fargate.sidecarConfigMapName" . }}
+
+2. Add the sidecar container alongside your app container:
+
+          containers:
+            - name: otel-collector-sidecar
+              image: {{ .Values.otelGateway.image.repository }}:{{ .Values.otelGateway.image.tag }}
+              command: ["/otelcol-contrib", "--config=/conf/otel-sidecar-config.yaml"]
+              env:
+                - name: K8S_CLUSTER_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: oodle-k8s-observability-fargate-config
+                      key: clusterName
+              resources:
+                requests:
+                  cpu: {{ .Values.otelSidecar.resources.requests.cpu }}
+                  memory: {{ .Values.otelSidecar.resources.requests.memory }}
+                limits:
+                  cpu: {{ .Values.otelSidecar.resources.limits.cpu }}
+                  memory: {{ .Values.otelSidecar.resources.limits.memory }}
+              volumeMounts:
+                - name: otel-sidecar-config
+                  mountPath: /conf
+
+3. If your app is instrumented with OpenTelemetry, set the exporter endpoint:
+
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+{{- if .Values.fargateLogging.enabled }}
+
+📝 LOGGING: Fargate Fluent Bit -> Oodle
+
+   Host:  {{ include "oodle-fargate.logsHost" . }}
+   Port:  {{ .Values.fargateLogging.es.port }}
+   Index: {{ .Values.fargateLogging.es.index }}
+
+   Logs are sent directly from Fargate's built-in Fluent Bit to Oodle
+   using the `es` output plugin. No Firehose or CloudWatch needed.
+
+   Pre-requisite: Ensure the Fargate Pod Execution Role has outbound
+   HTTPS access to {{ include "oodle-fargate.logsHost" . }}.
+
+   After enabling, restart your Fargate Deployments.
+   You should see a "LoggingEnabled" event on each pod.
+{{- end }}
+
+⚠️  MIXED CLUSTER NOTE
+   If you also run the oodle-k8s-observability chart (EC2) in this cluster,
+   disable shared components to avoid duplicates:
+
+     --set event-exporter.enabled=false
+
+
+🔍 To check the status of your installation:
+
+   helm list -n {{ .Release.Namespace }}
+   kubectl get pods -n {{ .Release.Namespace }}
+
+📚 For more information:
+   - Documentation: https://docs.oodle.ai
+   - GitHub: https://github.com/oodle-ai/oodle-k8s-observability-helm
+
+Happy monitoring! 🚀

--- a/charts/oodle-k8s-observability-fargate/templates/_helpers.tpl
+++ b/charts/oodle-k8s-observability-fargate/templates/_helpers.tpl
@@ -1,0 +1,139 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oodle-fargate.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "oodle-fargate.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oodle-fargate.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "oodle-fargate.labels" -}}
+helm.sh/chart: {{ include "oodle-fargate.chart" . }}
+{{ include "oodle-fargate.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "oodle-fargate.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oodle-fargate.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Gateway selector labels
+*/}}
+{{- define "oodle-fargate.gatewaySelectorLabels" -}}
+app.kubernetes.io/name: {{ include "oodle-fargate.name" . }}-gateway
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: gateway
+{{- end }}
+
+{{/*
+Gateway labels
+*/}}
+{{- define "oodle-fargate.gatewayLabels" -}}
+helm.sh/chart: {{ include "oodle-fargate.chart" . }}
+{{ include "oodle-fargate.gatewaySelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Resolve the OTLP host endpoint.
+If oodleOtlpHost is set, use it. Otherwise derive from oodleInstance.
+*/}}
+{{- define "oodle-fargate.otlpHost" -}}
+{{- if .Values.oodleConfig.oodleOtlpHost }}
+{{- .Values.oodleConfig.oodleOtlpHost }}
+{{- else }}
+{{- printf "https://%s-otlp.collector.oodle.ai" .Values.oodleConfig.oodleInstance }}
+{{- end }}
+{{- end }}
+
+{{/*
+Gateway service name
+*/}}
+{{- define "oodle-fargate.gatewayServiceName" -}}
+{{- printf "%s-otel-gateway" (include "oodle-fargate.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Sidecar service account name
+*/}}
+{{- define "oodle-fargate.sidecarServiceAccountName" -}}
+{{- printf "%s-otel-sidecar" (include "oodle-fargate.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Sidecar configmap name
+*/}}
+{{- define "oodle-fargate.sidecarConfigMapName" -}}
+{{- printf "%s-otel-sidecar-config" (include "oodle-fargate.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+List of namespaces to deploy sidecar resources into.
+Returns targetNamespaces if set, otherwise the release namespace.
+*/}}
+{{- define "oodle-fargate.sidecarNamespaces" -}}
+{{- if .Values.targetNamespaces }}
+{{- .Values.targetNamespaces | toJson }}
+{{- else }}
+{{- list .Release.Namespace | toJson }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the Oodle logs host for ES bulk API proxy.
+If oodleLogsHost is set, use it. Otherwise derive from oodleInstance.
+*/}}
+{{- define "oodle-fargate.logsHost" -}}
+{{- if .Values.fargateLogging.oodleLogsHost }}
+{{- .Values.fargateLogging.oodleLogsHost }}
+{{- else }}
+{{- printf "%s-logs.collector.oodle.ai" .Values.oodleConfig.oodleInstance }}
+{{- end }}
+{{- end }}
+
+{{/*
+Validate required values
+*/}}
+{{- define "oodle-fargate.validateRequired" -}}
+{{- if not .Values.oodleConfig.clusterName }}
+  {{- fail "oodleConfig.clusterName is required" }}
+{{- end }}
+{{- if not .Values.oodleConfig.oodleInstance }}
+  {{- fail "oodleConfig.oodleInstance is required" }}
+{{- end }}
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/templates/aws-logging-configmap.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/aws-logging-configmap.yaml
@@ -1,0 +1,57 @@
+{{/*
+  Fargate Fluent Bit Logging ConfigMap
+  ====================================
+  Debugging operational logs:
+  1. Set flb_log_cw to "true" in this ConfigMap (or via values fargateLogging.debugCloudWatch: true)
+  2. Ensure the Fargate Pod Execution Role has CloudWatch Logs permissions for
+     the log group: <EKS-cluster-name>-fluent-bit-logs (note: no /aws/eks/ prefix)
+  3. Restart the Fargate pods: kubectl rollout restart deployment <name> -n <namespace>
+  4. Tail operational logs: aws logs tail <EKS-cluster-name>-fluent-bit-logs --follow --region <region>
+*/}}
+{{- if .Values.fargateLogging.enabled }}
+{{- if not .Values.oodleConfig.apiKey }}
+  {{- fail "oodleConfig.apiKey is required when fargateLogging is enabled" }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-logging
+  namespace: aws-observability
+  labels:
+    {{- include "oodle-fargate.labels" . | nindent 4 }}
+data:
+  flb_log_cw: {{ .Values.fargateLogging.flbLogCw | default false | quote }}
+  filters.conf: |
+    [FILTER]
+        Name parser
+        Match *
+        Key_name log
+        Parser crio
+    [FILTER]
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        Buffer_Size 0
+        Kube_Meta_Cache_TTL 300s
+        Annotations Off
+        Labels Off
+  output.conf: |
+    [OUTPUT]
+        Name es
+        Match *
+        Host {{ include "oodle-fargate.logsHost" . }}
+        Port {{ .Values.fargateLogging.es.port }}
+        TLS {{ .Values.fargateLogging.es.tls }}
+        Suppress_Type_Name {{ .Values.fargateLogging.es.suppressTypeName }}
+        Index {{ .Values.fargateLogging.es.index }}
+        HTTP_User Bearer
+        HTTP_Passwd {{ .Values.oodleConfig.apiKey }}
+  parsers.conf: |
+    [PARSER]
+        Name crio
+        Format Regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>P|F) (?<log>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/templates/aws-observability-namespace.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/aws-observability-namespace.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.fargateLogging.enabled .Values.fargateLogging.createAwsObservabilityNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-observability
+  labels:
+    aws-observability: enabled
+    {{- include "oodle-fargate.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/templates/configmap.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- include "oodle-fargate.validateRequired" . }}
+{{- if .Values.oodleConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oodle-k8s-observability-fargate-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oodle-fargate.labels" . | nindent 4 }}
+data:
+  clusterName: {{ .Values.oodleConfig.clusterName | quote }}
+  oodleInstance: {{ .Values.oodleConfig.oodleInstance | quote }}
+  oodleOtlpHost: {{ include "oodle-fargate.otlpHost" . | quote }}
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/templates/otel-gateway-configmap.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/otel-gateway-configmap.yaml
@@ -1,0 +1,187 @@
+{{- if .Values.otelGateway.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "oodle-fargate.gatewayServiceName" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oodle-fargate.gatewayLabels" . | nindent 4 }}
+data:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: in-cluster
+      cluster:
+        server: https://kubernetes.default.svc:443
+        certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    contexts:
+    - name: in-cluster
+      context: { cluster: in-cluster, user: in-cluster }
+    current-context: in-cluster
+    users:
+    - name: in-cluster
+      user:
+        tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  otel-gateway-config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:{{ .Values.otelGateway.service.otlpGrpcPort }}
+            max_recv_msg_size_mib: 4
+          http:
+            endpoint: 0.0.0.0:{{ .Values.otelGateway.service.otlpHttpPort }}
+
+      {{- if .Values.otelGateway.k8sCluster.enabled }}
+      k8s_cluster:
+        auth_type: serviceAccount
+        collection_interval: {{ .Values.otelGateway.k8sCluster.collectionInterval }}
+        node_conditions_to_report:
+        {{- range .Values.otelGateway.k8sCluster.nodeConditionsToReport }}
+        - {{ . }}
+        {{- end }}
+        allocatable_types_to_report:
+        {{- range .Values.otelGateway.k8sCluster.allocatableTypesToReport }}
+        - {{ . }}
+        {{- end }}
+      {{- end }}
+
+      {{- if .Values.otelGateway.kubeletstats.enabled }}
+      kubeletstats:
+        auth_type: kubeConfig
+        collection_interval: {{ .Values.otelGateway.kubeletstats.collectionInterval }}
+        endpoint: ${env:K8S_NODE_NAME}
+        insecure_skip_verify: true
+        metric_groups:
+        {{- range .Values.otelGateway.kubeletstats.metricGroups }}
+        - {{ . }}
+        {{- end }}
+        metrics:
+          container.cpu.usage:
+            enabled: true
+          container.uptime:
+            enabled: true
+          k8s.container.cpu_limit_utilization:
+            enabled: true
+          k8s.container.cpu_request_utilization:
+            enabled: true
+          k8s.container.memory_limit_utilization:
+            enabled: true
+          k8s.container.memory_request_utilization:
+            enabled: true
+          k8s.node.cpu.usage:
+            enabled: true
+          k8s.node.uptime:
+            enabled: true
+          k8s.pod.cpu.usage:
+            enabled: true
+          k8s.pod.cpu_limit_utilization:
+            enabled: true
+          k8s.pod.cpu_request_utilization:
+            enabled: true
+          k8s.pod.memory_limit_utilization:
+            enabled: true
+          k8s.pod.memory_request_utilization:
+            enabled: true
+          k8s.pod.uptime:
+            enabled: true
+      {{- end }}
+
+    processors:
+      batch:
+        send_batch_size: {{ .Values.otelGateway.batch.sendBatchSize }}
+        timeout: {{ .Values.otelGateway.batch.timeout }}
+
+      k8sattributes:
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.deployment.name
+            - k8s.statefulset.name
+            - k8s.daemonset.name
+            - k8s.cronjob.name
+            - k8s.job.name
+            - k8s.node.name
+            - k8s.node.uid
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.pod.start_time
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+
+      resourcedetection:
+        detectors:
+        - eks
+        - env
+        - system
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+            os.type:
+              enabled: true
+        timeout: 2s
+
+    exporters:
+      otlphttp/oodle:
+        endpoint: ${env:OODLE_OTLP_HOST}
+        headers:
+          X-OODLE-INSTANCE: ${env:OODLE_INSTANCE}
+          X-API-KEY: ${env:OODLE_API_KEY}
+        timeout: {{ .Values.otelGateway.export.timeout }}
+        {{- if .Values.otelGateway.export.retry.enabled }}
+        retry_on_failure:
+          enabled: true
+          initial_interval: {{ .Values.otelGateway.export.retry.initialInterval }}
+          max_interval: {{ .Values.otelGateway.export.retry.maxInterval }}
+          max_elapsed_time: {{ .Values.otelGateway.export.retry.maxElapsedTime }}
+        {{- end }}
+
+      debug:
+        sampling_initial: 2
+        sampling_thereafter: 500
+        verbosity: basic
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers:
+            - otlp
+            {{- if .Values.otelGateway.k8sCluster.enabled }}
+            - k8s_cluster
+            {{- end }}
+            {{- if .Values.otelGateway.kubeletstats.enabled }}
+            - kubeletstats
+            {{- end }}
+          processors: [resourcedetection, k8sattributes, batch]
+          exporters: [otlphttp/oodle, debug]
+        {{- if .Values.traces.enabled }}
+        traces:
+          receivers: [otlp]
+          processors: [resourcedetection, k8sattributes, batch]
+          exporters: [otlphttp/oodle, debug]
+        {{- end }}
+      telemetry:
+        logs:
+          encoding: json
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/templates/otel-gateway-deployment.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/otel-gateway-deployment.yaml
@@ -1,0 +1,153 @@
+{{- if .Values.otelGateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oodle-fargate.gatewayServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oodle-fargate.gatewayLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.otelGateway.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "oodle-fargate.gatewaySelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/otel-gateway-configmap.yaml") . | sha256sum }}
+        {{- with .Values.otelGateway.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "oodle-fargate.gatewaySelectorLabels" . | nindent 8 }}
+        {{- with .Values.otelGateway.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "oodle-fargate.sidecarServiceAccountName" . }}
+      volumes:
+        - name: otel-gateway-config
+          configMap:
+            name: {{ include "oodle-fargate.gatewayServiceName" . }}-config
+      containers:
+        - name: otel-collector
+          image: "{{ .Values.otelGateway.image.repository }}:{{ .Values.otelGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.otelGateway.image.pullPolicy }}
+          command:
+            - /otelcol-contrib
+            - --config=/conf/otel-gateway-config.yaml
+          env:
+            - name: OODLE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apiKeySecret.name }}
+                  key: {{ .Values.apiKeySecret.key }}
+            - name: OODLE_INSTANCE
+              valueFrom:
+                configMapKeyRef:
+                  name: oodle-k8s-observability-fargate-config
+                  key: oodleInstance
+            - name: OODLE_OTLP_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: oodle-k8s-observability-fargate-config
+                  key: oodleOtlpHost
+            - name: K8S_CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: oodle-k8s-observability-fargate-config
+                  key: clusterName
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.node.name=$(K8S_NODE_NAME)"
+            - name: KUBECONFIG
+              value: /conf/kubeconfig
+          ports:
+            - containerPort: {{ .Values.otelGateway.service.otlpGrpcPort }}
+              name: otlp-grpc
+              protocol: TCP
+            - containerPort: {{ .Values.otelGateway.service.otlpHttpPort }}
+              name: otlp-http
+              protocol: TCP
+            - containerPort: 13133
+              name: health-check
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.otelGateway.resources | nindent 12 }}
+          volumeMounts:
+            - name: otel-gateway-config
+              mountPath: /conf
+      {{- with .Values.otelGateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.otelGateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.otelGateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oodle-fargate.gatewayServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "oodle-fargate.gatewayLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.otelGateway.service.type }}
+  selector:
+    {{- include "oodle-fargate.gatewaySelectorLabels" . | nindent 4 }}
+  ports:
+    - name: otlp-grpc
+      port: {{ .Values.otelGateway.service.otlpGrpcPort }}
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: {{ .Values.otelGateway.service.otlpHttpPort }}
+      targetPort: otlp-http
+      protocol: TCP
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/templates/otel-sidecar-configmap.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/otel-sidecar-configmap.yaml
@@ -1,0 +1,77 @@
+{{- $root := . }}
+{{- $namespaces := include "oodle-fargate.sidecarNamespaces" . | fromJsonArray }}
+{{- range $ns := $namespaces }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "oodle-fargate.sidecarConfigMapName" $root }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "oodle-fargate.labels" $root | nindent 4 }}
+data:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: in-cluster
+      cluster:
+        server: https://kubernetes.default.svc:443
+        certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    contexts:
+    - name: in-cluster
+      context: { cluster: in-cluster, user: in-cluster }
+    current-context: in-cluster
+    users:
+    - name: in-cluster
+      user:
+        tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  otel-sidecar-config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+            max_recv_msg_size_mib: 4
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        send_batch_size: 10000
+        timeout: 200ms
+
+      resource:
+        attributes:
+          - key: k8s.cluster.name
+            value: ${env:K8S_CLUSTER_NAME}
+            action: upsert
+
+    exporters:
+      otlp/gateway:
+        endpoint: {{ include "oodle-fargate.gatewayServiceName" $root }}.{{ $root.Release.Namespace }}.svc.cluster.local:{{ $root.Values.otelGateway.service.otlpGrpcPort }}
+        tls:
+          insecure: true
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [resource, batch]
+          exporters: [otlp/gateway]
+        {{- if $root.Values.traces.enabled }}
+        traces:
+          receivers: [otlp]
+          processors: [resource, batch]
+          exporters: [otlp/gateway]
+        {{- end }}
+      telemetry:
+        logs:
+          encoding: json
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/templates/rbac.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/rbac.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "oodle-fargate.fullname" . }}-otel-collector
+  labels:
+    {{- include "oodle-fargate.labels" . | nindent 4 }}
+rules:
+  # kubeletstats: API server proxy to kubelet
+  - apiGroups: ['']
+    resources: ['nodes/stats', 'nodes/proxy']
+    verbs: ['get']
+  # k8sattributes + k8s_cluster: core resources
+  - apiGroups: ['']
+    resources: ['pods', 'namespaces', 'nodes', 'endpoints', 'events', 'services', 'resourcequotas', 'replicationcontrollers']
+    verbs: ['get', 'list', 'watch']
+  # k8s_cluster: apps resources
+  - apiGroups: ['apps']
+    resources: ['replicasets', 'deployments', 'daemonsets', 'statefulsets']
+    verbs: ['get', 'list', 'watch']
+  # k8s_cluster: batch resources
+  - apiGroups: ['batch']
+    resources: ['jobs', 'cronjobs']
+    verbs: ['get', 'list', 'watch']
+  # k8s_cluster: autoscaling
+  - apiGroups: ['autoscaling']
+    resources: ['horizontalpodautoscalers']
+    verbs: ['get', 'list', 'watch']
+---
+{{- $root := . }}
+{{- $namespaces := include "oodle-fargate.sidecarNamespaces" . | fromJsonArray }}
+{{- range $ns := $namespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "oodle-fargate.fullname" $root }}-otel-collector-{{ $ns }}
+  labels:
+    {{- include "oodle-fargate.labels" $root | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "oodle-fargate.fullname" $root }}-otel-collector
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "oodle-fargate.sidecarServiceAccountName" $root }}
+    namespace: {{ $ns }}
+---
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/templates/serviceaccount.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- $root := . }}
+{{- $namespaces := include "oodle-fargate.sidecarNamespaces" . | fromJsonArray }}
+{{- range $ns := $namespaces }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oodle-fargate.sidecarServiceAccountName" $root }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "oodle-fargate.labels" $root | nindent 4 }}
+{{- end }}

--- a/charts/oodle-k8s-observability-fargate/values.yaml
+++ b/charts/oodle-k8s-observability-fargate/values.yaml
@@ -1,0 +1,257 @@
+# =============================================================================
+# Oodle Kubernetes Observability for EKS Fargate
+# =============================================================================
+#
+# IMPORTANT: Before installing this chart, create a Kubernetes Secret with your Oodle API key:
+#   kubectl create secret generic oodle-api-key --from-literal=apiKey=YOUR_API_KEY
+#
+# The chart expects a secret named 'oodle-api-key' with key 'apiKey' by default.
+
+# =============================================================================
+# OODLE CONFIGURATION
+# =============================================================================
+oodleConfig:
+  enabled: true
+
+  # Cluster name for Kubernetes cluster identification
+  clusterName: ""
+
+  # Oodle instance identifier (e.g., inst-your-instance-id)
+  oodleInstance: ""
+
+  # Oodle OTLP host endpoint (optional)
+  # If not specified, defaults to: https://{oodleInstance}-otlp.collector.oodle.ai
+  oodleOtlpHost: ""
+
+  # Oodle API key
+  # Used by Fargate Fluent Bit logging (rendered in plaintext in the aws-logging
+  # ConfigMap — a known limitation of Fargate's managed log router).
+  # The OTel gateway reads the key from the Kubernetes Secret (apiKeySecret) instead.
+  apiKey: ""
+
+# Secret reference for API key (used by OTel gateway and event-exporter)
+apiKeySecret:
+  name: oodle-api-key
+  key: apiKey
+
+# =============================================================================
+# TARGET NAMESPACES
+# =============================================================================
+# Namespaces where the sidecar ServiceAccount and ConfigMap should be created.
+# If empty, only the release namespace is used.
+# Example: ["app-ns-a", "app-ns-b"]
+targetNamespaces: []
+
+# =============================================================================
+# OTEL COLLECTOR GATEWAY
+# =============================================================================
+# Central OTel Collector Deployment that receives metrics from sidecars
+# and collects kubeletstats. Exports to Oodle via OTLP HTTP.
+otelGateway:
+  enabled: true
+
+  image:
+    repository: otel/opentelemetry-collector-contrib
+    tag: 0.139.0
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+  # OTLP export settings
+  export:
+    timeout: 120s
+    retry:
+      enabled: true
+      initialInterval: 2s
+      maxInterval: 45s
+      maxElapsedTime: 12m
+
+  # k8s_cluster receiver settings (cluster-level object metrics from API server)
+  # Collects: deployment replicas, pod phases, node conditions, namespace status,
+  # container restarts, DaemonSet/StatefulSet/ReplicaSet/Job/CronJob/HPA status
+  k8sCluster:
+    enabled: true
+    collectionInterval: 30s
+    nodeConditionsToReport:
+      - Ready
+      - MemoryPressure
+      - DiskPressure
+      - PIDPressure
+    allocatableTypesToReport:
+      - cpu
+      - memory
+      - storage
+
+  # Kubeletstats receiver settings (pod/container/node metrics via API proxy)
+  kubeletstats:
+    enabled: true
+    collectionInterval: 30s
+    metricGroups:
+      - container
+      - pod
+      - node
+      - volume
+
+  # Batch processor settings
+  batch:
+    sendBatchSize: 10000
+    timeout: 200ms
+
+  # Service configuration
+  service:
+    type: ClusterIP
+    otlpGrpcPort: 4317
+    otlpHttpPort: 4318
+
+  # Pod annotations
+  podAnnotations: {}
+
+  # Pod labels
+  podLabels: {}
+
+  # Node selector
+  nodeSelector: {}
+
+  # Tolerations
+  tolerations: []
+
+  # Affinity
+  affinity: {}
+
+# =============================================================================
+# OTEL SIDECAR CONFIGURATION
+# =============================================================================
+# Resource settings for the OTel sidecar container that customers add to
+# their Fargate Deployments. These values are rendered in the NOTES.txt
+# sidecar snippet.
+otelSidecar:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+# =============================================================================
+# FARGATE LOGGING (Fluent Bit -> Elasticsearch bulk API proxy)
+# =============================================================================
+# Configures the AWS-managed Fluent Bit log router on Fargate to send
+# container logs directly to Oodle's ES bulk API proxy endpoint.
+#
+# This uses the Fluent Bit `es` output plugin, which is one of the
+# AWS-approved outputs for Fargate. No Firehose or CloudWatch needed.
+#
+# Auth: Uses HTTP Basic auth (HTTP_User=Bearer, HTTP_Passwd=<apiKey>) because
+# Fargate's managed Fluent Bit does not support the "Header" directive.
+# The receiving proxy must decode the Basic auth to extract the API key.
+#
+# Pre-requisites (customer must do before enabling):
+#   1. Fargate Pod Execution Role needs outbound HTTPS access to the Oodle logs host.
+#   2. Pods must be restarted after enabling — Fargate reads the ConfigMap at schedule time only.
+#
+# Debugging:
+#   To enable Fluent Bit operational logs in CloudWatch:
+#   1. Set fargateLogging.flbLogCw to true
+#   2. Add CloudWatch Logs permissions to the Fargate Pod Execution Role for
+#      log group: <EKS-cluster-name>-fluent-bit-logs (note: no /aws/eks/ prefix)
+#   3. Restart pods, then: aws logs tail <EKS-cluster-name>-fluent-bit-logs --follow --region <region>
+fargateLogging:
+  enabled: false
+
+  # Enable Fluent Bit operational logs to CloudWatch for debugging (default: false)
+  # Requires CloudWatch Logs IAM permissions on the Fargate Pod Execution Role.
+  flbLogCw: false
+
+  # Create the aws-observability namespace (required by Fargate log router)
+  createAwsObservabilityNamespace: true
+
+  # Oodle logs host running the ES bulk API proxy (REQUIRED when enabled)
+  # If not specified, defaults to: {oodleInstance}-logs.collector.oodle.ai
+  oodleLogsHost: ""
+
+  # Elasticsearch output settings
+  es:
+    # Port for the ES endpoint
+    port: "443"
+    # TLS enabled
+    tls: "On"
+    # Suppress the Fluent Bit type prefix
+    suppressTypeName: "On"
+    # Index name for logs
+    index: "oodle-logs"
+
+# =============================================================================
+# TRACES
+# =============================================================================
+# When enabled, the gateway and sidecars accept traces via OTLP.
+# Requires application instrumentation with OpenTelemetry SDKs.
+traces:
+  enabled: false
+
+# =============================================================================
+# KUBERNETES EVENT EXPORTER (subchart)
+# =============================================================================
+# Exports Kubernetes events to Oodle. Disabled by default for metrics-only.
+# Enable when you add logging/events support.
+event-exporter:
+  enabled: false
+
+  image:
+    registry: "public.ecr.aws/oodle-ai"
+    repository: kubernetes-event-exporter
+    tag: 1.7.0-debian-12-r46
+
+  global:
+    security:
+      allowInsecureImages: true
+
+  extraEnvVars:
+    - name: CLUSTER_NAME
+      valueFrom:
+        configMapKeyRef:
+          name: oodle-k8s-observability-fargate-config
+          key: clusterName
+    - name: OODLE_INSTANCE
+      valueFrom:
+        configMapKeyRef:
+          name: oodle-k8s-observability-fargate-config
+          key: oodleInstance
+    - name: OODLE_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: oodle-api-key
+          key: apiKey
+    - name: OODLE_OTLP_HOST
+      valueFrom:
+        configMapKeyRef:
+          name: oodle-k8s-observability-fargate-config
+          key: oodleOtlpHost
+
+  config:
+    clusterName: "${CLUSTER_NAME}"
+    kubeQPS: 100
+    kubeBurst: 500
+    maxEventAgeSeconds: 600
+    logLevel: info
+    logFormat: json
+    route:
+      routes:
+        - match:
+            - receiver: "oodle"
+    receivers:
+      - name: "oodle"
+        webhook:
+          endpoint: "${OODLE_OTLP_HOST}/v1/logs"
+          headers:
+            X-OODLE-INSTANCE: "${OODLE_INSTANCE}"
+            X-API-KEY: "${OODLE_API_KEY}"
+            X-OODLE-LOG-SOURCE: "event-exporter"

--- a/charts/oodle-k8s-observability-fargate/values.yaml
+++ b/charts/oodle-k8s-observability-fargate/values.yaml
@@ -150,9 +150,7 @@ otelSidecar:
 # This uses the Fluent Bit `es` output plugin, which is one of the
 # AWS-approved outputs for Fargate. No Firehose or CloudWatch needed.
 #
-# Auth: Uses HTTP Basic auth (HTTP_User=Bearer, HTTP_Passwd=<apiKey>) because
-# Fargate's managed Fluent Bit does not support the "Header" directive.
-# The receiving proxy must decode the Basic auth to extract the API key.
+# Auth: Uses HTTP Basic auth (HTTP_User=Bearer, HTTP_Passwd=<apiKey>)
 #
 # Pre-requisites (customer must do before enabling):
 #   1. Fargate Pod Execution Role needs outbound HTTPS access to the Oodle logs host.


### PR DESCRIPTION
## Summary
- Adds a new `oodle-k8s-observability-fargate` Helm chart purpose-built for EKS Fargate clusters
- Deploys an OTel Collector gateway with `k8s_cluster` receiver for cluster-level metrics, plus a sidecar ConfigMap for per-pod metric collection
- Supports Fargate native Fluent Bit logging to Oodle via the `es` output plugin (no Firehose/CloudWatch required)
- Includes Kubernetes event exporter subchart and optional OTLP traces support
- NOTES.txt styled consistently with the main `oodle-k8s-observability` chart

## Test plan
Tested in a dev eks cluster using fargate