### PR TITLE
Temporarily exclude fargate chart from release

### DIFF
--- a/.github/configs/ct.yaml
+++ b/.github/configs/ct.yaml
@@ -13,6 +13,7 @@ validate-chart-schema: true
 validate-maintainers: true
 validate-yaml: true
 exclude-deprecated: true
-excluded-charts: []
+excluded-charts:
+  - oodle-k8s-observability-fargate
 namespace: oodle-monitoring  # Need to set the namespace because we create the secret there
 release-label: app.kubernetes.io/instance


### PR DESCRIPTION
## Summary
- Excludes `oodle-k8s-observability-fargate` from `ct.yaml` so the release workflow can release the main chart without hitting the single-chart-changed limit
- This should be reverted after the main chart release, so the fargate chart can be released next

## Test plan
- [ ] Merge and run the `Release Helm chart` workflow — should detect only `oodle-k8s-observability` as changed
- [ ] After successful release, revert this exclusion in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)