### PR TITLE
Revert fargate chart exclusion from release

### DIFF
--- a/.github/configs/ct.yaml
+++ b/.github/configs/ct.yaml
@@ -13,7 +13,6 @@ validate-chart-schema: true
 validate-maintainers: true
 validate-yaml: true
 exclude-deprecated: true
-excluded-charts:
-  - oodle-k8s-observability-fargate
+excluded-charts: []
 namespace: oodle-monitoring  # Need to set the namespace because we create the secret there
 release-label: app.kubernetes.io/instance


### PR DESCRIPTION
## Summary
- Reverts the temporary exclusion of `oodle-k8s-observability-fargate` from `ct.yaml`
- The main chart has been released — this unblocks the fargate chart for its first release

## Test plan
- [ ] Merge and run the `Release Helm chart` workflow — should detect only `oodle-k8s-observability-fargate` as changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)