### PR TITLE
Fix release workflow tag match pattern

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           cd source
 
-          latest_tag=$( if ! git describe --tags --abbrev=0 --match='helm-chart/*' 2> /dev/null ; then git rev-list --max-parents=0 --first-parent HEAD; fi )
+          latest_tag=$( if ! git describe --tags --abbrev=0 --match='v*' 2> /dev/null ; then git rev-list --max-parents=0 --first-parent HEAD; fi )
 
           echo "Running: ct list-changed --config \"${CT_CONFIGFILE}\" --since \"${latest_tag}\" --target-branch ${{ github.ref_name }}"
           changed=$(ct list-changed --config "${CT_CONFIGFILE}" --since "${latest_tag}" --target-branch "${{ github.ref_name }}")


### PR DESCRIPTION
## Summary
- Changes `--match='helm-chart/*'` to `--match='v*'` in the release workflow's `latest_tag` lookup
- All release tags in this repo use the `v*` format (e.g. `v1.0.27`), but the lookup was searching for `helm-chart/*` which never matched anything
- This caused `ct list-changed` to always compare against the first commit, listing every chart as changed — broke the workflow once a second chart was added

## Test plan
- [ ] Merge and run the `Release Helm chart` workflow — should detect only `oodle-k8s-observability-fargate` as changed (since the main chart was already released as `v1.0.27`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)