### PR TITLE
feat: Add cluster label to Fargate Fluent Bit logs

### DIFF
--- a/charts/oodle-k8s-observability-fargate/templates/aws-logging-configmap.yaml
+++ b/charts/oodle-k8s-observability-fargate/templates/aws-logging-configmap.yaml
@@ -38,6 +38,10 @@ data:
         Kube_Meta_Cache_TTL 300s
         Annotations Off
         Labels Off
+    [FILTER]
+        Name record_modifier
+        Match *
+        Record cluster {{ .Values.oodleConfig.clusterName }}
   output.conf: |
     [OUTPUT]
         Name es


### PR DESCRIPTION
## Summary
- Add a `record_modifier` Fluent Bit filter to the aws-logging ConfigMap that injects a `cluster` field into every log record
- Uses the existing `oodleConfig.clusterName` chart input, matching the pattern used by the OTel gateway for metrics/traces

## Test plan
- [ ] `helm template` with `clusterName` set — verify `record_modifier` filter in aws-logging ConfigMap
- [ ] Deploy to Fargate cluster and confirm logs include the `cluster` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)