### PR TITLE
fix: route event-exporter logs to ingest endpoint

### DIFF
--- a/charts/oodle-k8s-observability-fargate/Chart.yaml
+++ b/charts/oodle-k8s-observability-fargate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oodle-k8s-observability-fargate
 description: A Helm chart for Oodle Kubernetes observability on EKS Fargate
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.2.1"
 home: https://github.com/oodle-ai/oodle-k8s-observability-helm
 sources:

--- a/charts/oodle-k8s-observability-fargate/values.yaml
+++ b/charts/oodle-k8s-observability-fargate/values.yaml
@@ -220,7 +220,7 @@ event-exporter:
     receivers:
       - name: "oodle"
         webhook:
-          endpoint: "${OODLE_OTLP_HOST}/v1/logs"
+          endpoint: "${OODLE_OTLP_HOST}/ingest/v1/logs"
           headers:
             X-OODLE-INSTANCE: "${OODLE_INSTANCE}"
             X-API-KEY: "${OODLE_API_KEY}"


### PR DESCRIPTION
- Update the Fargate chart default event-exporter webhook endpoint from
  `/v1/logs` to `/ingest/v1/logs`.
- Ensure Kubernetes event payloads are sent to the ingest path that
  accepts webhook-style event data.
- Avoid using the OTLP-specific `/v1/logs` path for non-OTLP
  event-exporter payloads.

- [x] Deploy chart with `event-exporter.enabled=true`.
- [x] Verify event-exporter logs show successful sends.
- [x] Verify receiver/controller logs show `POST /ingest/v1/logs` with
  `200` responses.